### PR TITLE
Prevent tools page crash on ungrouped tools

### DIFF
--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -75,7 +75,9 @@ func init() {
 
 // ToolsetsFor reports which named toolsets include a tool.
 func ToolsetsFor(name string) []string {
-	var out []string
+	// Keep this non-nil so JSON clients receive [] rather than null for dynamic
+	// tools (for example MCP tools) that are not members of a named preset.
+	out := []string{}
 	for set, members := range Toolsets {
 		if set == "all" {
 			continue

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -1,0 +1,20 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestToolsetsForUnknownToolEncodesAsEmptyArray(t *testing.T) {
+	sets := ToolsetsFor("mcp__dynamic__not-in-a-preset")
+	if sets == nil || len(sets) != 0 {
+		t.Fatalf("ToolsetsFor unknown tool = %#v, want non-nil empty slice", sets)
+	}
+	got, err := json.Marshal(sets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "[]" {
+		t.Fatalf("JSON = %s, want []", got)
+	}
+}

--- a/web/src/lib/toolPayload.test.mjs
+++ b/web/src/lib/toolPayload.test.mjs
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test'
+import { toolsetsOrEmpty } from './toolPayload.ts'
+
+describe('tool payload normalization', () => {
+  test('turns null or missing toolsets into an empty array', () => {
+    expect(toolsetsOrEmpty(null)).toEqual([])
+    expect(toolsetsOrEmpty(undefined)).toEqual([])
+  })
+
+  test('keeps valid toolset arrays', () => {
+    const sets = ['default', 'coding']
+    expect(toolsetsOrEmpty(sets)).toBe(sets)
+    expect(toolsetsOrEmpty(sets).slice(0, 4)).toEqual(sets)
+  })
+})

--- a/web/src/lib/toolPayload.ts
+++ b/web/src/lib/toolPayload.ts
@@ -1,0 +1,3 @@
+export function toolsetsOrEmpty(value: string[] | null | undefined): string[] {
+  return Array.isArray(value) ? value : []
+}

--- a/web/src/pages/ToolsPage.tsx
+++ b/web/src/pages/ToolsPage.tsx
@@ -7,18 +7,19 @@ import { PageLayout } from '@/components/layout/PageLayout'
 import { Badge, EmptyState, Input, Switch } from '@/components/ui/primitives'
 import { SkeletonList } from '@/components/ui/skeleton'
 import { useI18n } from '@/lib/i18n'
+import { toolsetsOrEmpty } from '@/lib/toolPayload'
 
 interface ToolInfo {
   name: string
   description: string
   enabled: boolean
   requires_approval: boolean
-  toolsets: string[]
+  toolsets: string[] | null
 }
 
 interface ToolsResponse {
   toolset: string
-  toolsets: string[]
+  toolsets: string[] | null
   tools: ToolInfo[]
 }
 
@@ -71,7 +72,7 @@ export default function ToolsPage() {
           {t('tools.activeToolset')}
         </p>
         <div className="flex flex-wrap gap-1.5">
-          {data.toolsets.map((preset) => (
+          {toolsetsOrEmpty(data.toolsets).map((preset) => (
             <button
               key={preset}
               disabled={!!busy}
@@ -158,13 +159,13 @@ export default function ToolsPage() {
                     {t('tools.mutates')}
                   </Badge>
                 ) : null}
-                {item.toolsets.slice(0, 4).map((ts) => (
+                {toolsetsOrEmpty(item.toolsets).slice(0, 4).map((ts) => (
                   <Badge key={ts} variant="outline">
                     {ts}
                   </Badge>
                 ))}
-                {item.toolsets.length > 4 ? (
-                  <Badge variant="outline">+{item.toolsets.length - 4}</Badge>
+                {toolsetsOrEmpty(item.toolsets).length > 4 ? (
+                  <Badge variant="outline">+{toolsetsOrEmpty(item.toolsets).length - 4}</Badge>
                 ) : null}
               </div>
             </div>


### PR DESCRIPTION
## Summary

- encode toolset membership as `[]` instead of `null` for dynamic/ungrouped tools such as MCP tools
- defensively normalize nullable `toolsets` payloads in the Tools page for compatibility with older servers and cached responses
- add backend JSON and frontend normalization regression tests

## Root cause

`ToolsetsFor` returned a nil Go slice for tools not present in named presets. JSON encoded that as `null`, while the UI assumed `string[]` and called `item.toolsets.slice(...)`, causing:

```text
Cannot read properties of null (reading 'slice')
```

## Verification

- `make check`
- 6 web tests, 0 failures
- TypeScript + Vite production build
- Brave smoke test, 15/15 routes
- installed live bundle contains `Array.isArray(toolsets) ? toolsets : []`
- live daemon health is 200 after restart