### PR TITLE
Fail fast when persistent terminal shell exits

### DIFF
--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/enowdev/antares/internal/config"
@@ -56,9 +57,10 @@ type shellSession struct {
 	cmd      *exec.Cmd
 	stdin    io.WriteCloser
 	out      *lockedBuffer
+	done     chan struct{}
 	lastUsed time.Time
 	cwd      string
-	dead     bool
+	dead     atomic.Bool
 }
 
 // lockedBuffer collects interleaved stdout/stderr safely.
@@ -139,7 +141,7 @@ func defaultShell(configured string) (string, []string) {
 func (m *ShellManager) session(id, workspace string) (*shellSession, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if s, ok := m.sessions[id]; ok && !s.dead && s.cmd.ProcessState == nil {
+	if s, ok := m.sessions[id]; ok && !s.dead.Load() {
 		s.lastUsed = time.Now()
 		return s, nil
 	}
@@ -203,12 +205,14 @@ func (m *ShellManager) session(id, workspace string) (*shellSession, error) {
 		return nil, fmt.Errorf("start shell: %w", err)
 	}
 
-	s := &shellSession{cmd: cmd, stdin: stdin, out: out, lastUsed: time.Now(), cwd: workspace}
+	s := &shellSession{
+		cmd: cmd, stdin: stdin, out: out, done: make(chan struct{}),
+		lastUsed: time.Now(), cwd: workspace,
+	}
 	go func() {
 		_ = cmd.Wait()
-		s.mu.Lock()
-		s.dead = true
-		s.mu.Unlock()
+		s.dead.Store(true)
+		close(s.done)
 	}()
 	m.sessions[id] = s
 	return s, nil
@@ -288,7 +292,7 @@ func (s *shellSession) terminate() {
 	}
 	_ = s.stdin.Close()
 	_ = s.cmd.Process.Kill()
-	s.dead = true
+	s.dead.Store(true)
 }
 
 // sentinel marks the end of one command's output and carries its exit code.
@@ -298,16 +302,19 @@ const sentinelPrefix = "__ANTARES_DONE_"
 func (s *shellSession) run(ctx context.Context, command string, timeout time.Duration, onChunk func(string)) (string, int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.dead {
+	if s.dead.Load() {
 		return "", -1, fmt.Errorf("shell has exited")
 	}
 	s.lastUsed = time.Now()
 	s.out.drain()
 
 	marker := fmt.Sprintf("%s%d__", sentinelPrefix, time.Now().UnixNano())
-	script := command + "\nprintf '\\n" + marker + "%s\\n' \"$?\"\n"
+	// A terminal call may enable errexit (`set -e`). Shell options persist just
+	// like cwd and exported variables, but errexit must not leak into the next
+	// call and kill the shell before its completion sentinel can run.
+	script := "set +e\n" + command + "\nprintf '\\n" + marker + "%s\\n' \"$?\"\n"
 	if _, err := io.WriteString(s.stdin, script); err != nil {
-		s.dead = true
+		s.dead.Store(true)
 		return "", -1, fmt.Errorf("write to shell: %w", err)
 	}
 
@@ -320,6 +327,11 @@ func (s *shellSession) run(ctx context.Context, command string, timeout time.Dur
 		select {
 		case <-ctx.Done():
 			return s.finish(marker), -1, ctx.Err()
+		case <-s.done:
+			// The shell can exit before printing the sentinel (for example when a
+			// command enables `set -e` and then fails). Do not wait out the full
+			// timeout for a marker that can no longer arrive.
+			return s.finish(marker), -1, fmt.Errorf("shell exited before command completed")
 		case <-ticker.C:
 			buf := s.out.snapshot()
 			if onChunk != nil && len(buf) > sent {

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,5 +59,69 @@ func TestDefaultShellCommandEmitsCompletionSentinel(t *testing.T) {
 	}
 	if code != 0 || out != "ANTARES_SHELL_OK" {
 		t.Fatalf("command result = (%q, %d), want (%q, 0)", out, code, "ANTARES_SHELL_OK")
+	}
+}
+
+func TestPersistentShellErrexitDoesNotLeakBetweenCalls(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell options do not apply on Windows")
+	}
+
+	m := NewShellManager(config.Terminal{})
+	t.Cleanup(m.CloseAll)
+	sess, err := m.session("errexit-session", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, code, err := sess.run(context.Background(), "set -e; true", 2*time.Second, nil); err != nil || code != 0 {
+		t.Fatalf("enabling errexit = code %d, err %v", code, err)
+	}
+
+	start := time.Now()
+	_, code, err := sess.run(context.Background(), "printf x | grep definitely-no-match", 2*time.Second, nil)
+	if err != nil {
+		t.Fatalf("no-match pipeline after prior set -e did not reach sentinel: %v", err)
+	}
+	if code != 1 {
+		t.Fatalf("no-match pipeline exit code = %d, want 1", code)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("failure after prior set -e took %s, want prompt completion", elapsed)
+	}
+}
+
+func TestPersistentShellExitReturnsPromptlyAndRecovers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell exit behavior does not apply on Windows")
+	}
+
+	m := NewShellManager(config.Terminal{})
+	t.Cleanup(m.CloseAll)
+	workspace := t.TempDir()
+	sess, err := m.session("exit-session", workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	_, _, err = sess.run(context.Background(), "set -e; false", 5*time.Second, nil)
+	if err == nil || !strings.Contains(err.Error(), "shell exited") {
+		t.Fatalf("shell exit error = %v, want shell exited", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("shell exit detected after %s, want under 1s", elapsed)
+	}
+
+	replacement, err := m.session("exit-session", workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacement == sess {
+		t.Fatal("dead persistent shell was reused")
+	}
+	out, code, err := replacement.run(context.Background(), "printf RECOVERED", 2*time.Second, nil)
+	if err != nil || code != 0 || out != "RECOVERED" {
+		t.Fatalf("replacement shell result = (%q, %d, %v)", out, code, err)
 	}
 }


### PR DESCRIPTION
## Summary

- reset inherited `errexit` before every foreground terminal call so `set -e` does not leak across persistent-shell calls
- observe the shell process exit channel while waiting for the completion sentinel
- use atomic shell liveness state to avoid the previous `run`/`Wait` lock inversion
- replace a dead shell automatically on the next call

## Root cause

A prior call enabled `set -e`. A later no-match `grep` returned 1 and killed the persistent Bash before Antares could print its completion sentinel. The process had already exited, but `run()` held the session mutex while waiting only for the sentinel or the 300-second deadline. The `cmd.Wait()` goroutine therefore could not mark the shell dead, and the UI showed the terminal running for the full five minutes.

## Regression coverage

- `set -e` followed by a no-match pipeline returns exit 1 in under one second instead of timing out
- a shell that exits before its sentinel is detected in under one second despite a five-second command timeout
- the next call receives a replacement shell and succeeds

## Verification

- `go test -race -count=1 ./internal/tools`
- Windows amd64 cross-compile of `internal/tools` tests
- `make check`
- Brave smoke test: 15/15 routes