### PR TITLE
Preserve exact file content in editing workflows

### DIFF
--- a/internal/tools/file.go
+++ b/internal/tools/file.go
@@ -123,7 +123,7 @@ func resolveWrite(in Input, p string) (string, error) {
 			return clean, nil
 		}
 	}
-	return "", fmt.Errorf("path %q is outside this project — writes are only allowed inside %s (reads and copies from elsewhere are fine)",
+	return "", fmt.Errorf("path %q is outside this project — writes are only allowed inside %s (reads and copies from elsewhere are fine). Create temporary scripts inside the project or Antares workspace instead of /tmp",
 		p, strings.Join(in.WriteRoots, ", "))
 }
 
@@ -140,7 +140,7 @@ type readFileTool struct{}
 
 func (readFileTool) Name() string { return "read_file" }
 func (readFileTool) Description() string {
-	return "Read a text file from the workspace. Returns numbered lines. Use offset/limit for large files."
+	return "Read a text file from the workspace. Returns lines as NUMBER|CONTENT; the | separates metadata from exact file content and must not be copied into edits. Use offset/limit for large files."
 }
 func (readFileTool) Schema() map[string]any {
 	return schema(map[string]any{
@@ -204,7 +204,7 @@ func (readFileTool) Execute(_ context.Context, in Input) Result {
 
 	var b strings.Builder
 	for i := start; i < end; i++ {
-		fmt.Fprintf(&b, "%6d\t%s\n", i+1, lines[i])
+		fmt.Fprintf(&b, "%d|%s\n", i+1, lines[i])
 	}
 	if end < len(lines) {
 		fmt.Fprintf(&b, "\n… %d more lines (use offset=%d to continue)\n", len(lines)-end, end+1)
@@ -323,7 +323,7 @@ func (editFileTool) Execute(_ context.Context, in Input) Result {
 	count := strings.Count(content, args.OldString)
 	switch {
 	case count == 0:
-		return Errorf("old_string not found in %s. Read the file first and copy the exact text.", args.Path)
+		return Errorf("old_string not found in %s. Read the file first and copy only the content after the NUMBER| separator; preserve indentation exactly.", args.Path)
 	case count > 1 && !args.ReplaceAll:
 		return Errorf("old_string appears %d times in %s; add more surrounding context or set replace_all", count, args.Path)
 	}

--- a/internal/tools/file_edit_regression_test.go
+++ b/internal/tools/file_edit_regression_test.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadFileSeparatesLineNumbersFromTabbedUnicodeContent(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "remoteplayer.cpp")
+	original := "\t\t\tif (!m_pPlayerPed->IsInVehicle())\n\t\t\t{\n\t\t\t\t// preserve root motion — exactly\n\t\t\t}\n"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	readArgs, _ := json.Marshal(map[string]any{"path": "remoteplayer.cpp"})
+	read := (readFileTool{}).Execute(context.Background(), Input{Args: readArgs, Workspace: workspace})
+	if read.IsError {
+		t.Fatalf("read_file failed: %s", read.Content)
+	}
+	wantRead := "1|\t\t\tif (!m_pPlayerPed->IsInVehicle())\n2|\t\t\t{\n3|\t\t\t\t// preserve root motion — exactly\n4|\t\t\t}\n5|\n"
+	if read.Content != wantRead {
+		t.Fatalf("read output = %q, want %q", read.Content, wantRead)
+	}
+
+	var copied []string
+	for _, line := range strings.Split(strings.TrimSuffix(read.Content, "\n"), "\n")[:4] {
+		_, content, ok := strings.Cut(line, "|")
+		if !ok {
+			t.Fatalf("line lacks NUMBER| separator: %q", line)
+		}
+		copied = append(copied, content)
+	}
+	oldString := strings.Join(copied, "\n")
+	newString := strings.Replace(oldString, "exactly", "safely", 1)
+	editArgs, _ := json.Marshal(map[string]any{
+		"path": "remoteplayer.cpp", "old_string": oldString, "new_string": newString,
+	})
+	edited := (editFileTool{}).Execute(context.Background(), Input{Args: editArgs, Workspace: workspace})
+	if edited.IsError {
+		t.Fatalf("edit_file failed with content copied after separator: %s", edited.Content)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != strings.Replace(original, "exactly", "safely", 1) {
+		t.Fatalf("edited content = %q", got)
+	}
+}
+
+func TestProjectWriteErrorSuggestsInWorkspaceTemporaryScript(t *testing.T) {
+	project := t.TempDir()
+	workspace := t.TempDir()
+	_, err := resolveWrite(Input{Workspace: project, WriteRoots: []string{project, workspace}}, "/tmp/fix_remoteplayer.py")
+	if err == nil {
+		t.Fatal("outside write unexpectedly allowed")
+	}
+	if !strings.Contains(err.Error(), "inside the project or Antares workspace instead of /tmp") {
+		t.Fatalf("write error lacks actionable fallback: %v", err)
+	}
+}

--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -115,7 +115,10 @@ func withShimEnv(env []string, shim httpShimEnv) []string {
 
 func defaultShell(configured string) (string, []string) {
 	if configured != "" {
-		return configured, []string{"-i"}
+		// Persistent state does not require an interactive shell. Running with -i
+		// enables readline and history expansion, which corrupts pasted commands:
+		// literal tabs trigger completion and `!` raises "event not found".
+		return configured, nil
 	}
 	if runtime.GOOS == "windows" {
 		return "powershell.exe", []string{"-NoLogo", "-NoProfile", "-Command", "-"}

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -35,8 +36,8 @@ func TestDefaultShellHonorsExplicitConfiguration(t *testing.T) {
 	if shell != "/custom/shell" {
 		t.Fatalf("defaultShell(configured) = %q", shell)
 	}
-	if len(args) != 1 || args[0] != "-i" {
-		t.Fatalf("configured shell args = %#v, want [-i]", args)
+	if len(args) != 0 {
+		t.Fatalf("configured shell args = %#v, want non-interactive shell", args)
 	}
 }
 
@@ -58,5 +59,36 @@ func TestDefaultShellCommandEmitsCompletionSentinel(t *testing.T) {
 	}
 	if code != 0 || out != "ANTARES_SHELL_OK" {
 		t.Fatalf("command result = (%q, %d), want (%q, 0)", out, code, "ANTARES_SHELL_OK")
+	}
+}
+
+func TestPersistentShellPreservesLiteralTabsBangUnicodeAndHeredoc(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX persistent shell protocol does not apply on Windows")
+	}
+
+	m := NewShellManager(config.Terminal{Shell: "/bin/bash"})
+	t.Cleanup(m.CloseAll)
+	workspace := t.TempDir()
+	sess, err := m.session("literal-session", workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	command := "python3 - <<'PY'\nfrom pathlib import Path\nPath('literal.txt').write_text('\\tif (!ready) — ok\\n', encoding='utf-8')\nPY\ncat literal.txt"
+	out, code, err := sess.run(context.Background(), command, 2*time.Second, nil)
+	if err != nil || code != 0 {
+		t.Fatalf("literal command result = (%q, %d, %v)", out, code, err)
+	}
+	want := "\tif (!ready) — ok"
+	if out != want {
+		t.Fatalf("literal command output = %q, want %q", out, want)
+	}
+	data, err := os.ReadFile(filepath.Join(workspace, "literal.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != want+"\n" {
+		t.Fatalf("literal file = %q, want %q", data, want+"\n")
 	}
 }


### PR DESCRIPTION
## Summary

- render `read_file` lines as unambiguous `NUMBER|CONTENT` instead of `NUMBER<TAB>CONTENT`
- document that only content after the separator belongs in `edit_file.old_string`
- improve exact-match failure guidance
- run explicitly configured persistent shells non-interactively so literal tabs do not trigger completion and `!` does not trigger history expansion
- keep project write confinement while recommending temporary scripts inside the project or Antares workspace instead of `/tmp`

## Root cause

`read_file` used a tab between the line number and file content. For tab-indented C++, an assistant copying the displayed line could not distinguish the output separator tab from indentation, so every `old_string` line gained one tab and exact replacement failed. The fallback terminal then used an interactive bash: literal tabs triggered readline completion and C++ `!` triggered history expansion.

## Regression coverage

- tab-indented `remoteplayer.cpp`-style C++ with `!` and an em dash round-trips from `read_file` into `edit_file`
- persistent shell preserves literal tabs, `!`, Unicode, and a Python heredoc
- `/tmp` write remains blocked and returns actionable in-workspace guidance

## Verification

- `go test -race ./internal/tools`
- `make check`
- Windows amd64 cross-build
- Brave smoke: 15/15 routes
- original `virtual-evo` repository remains clean