### PR TITLE
Fix 300s timeout when foreground command spawns a daemon

### DIFF
--- a/internal/tools/shell.go
+++ b/internal/tools/shell.go
@@ -305,7 +305,19 @@ func (s *shellSession) run(ctx context.Context, command string, timeout time.Dur
 	s.out.drain()
 
 	marker := fmt.Sprintf("%s%d__", sentinelPrefix, time.Now().UnixNano())
-	script := command + "\nprintf '\\n" + marker + "%s\\n' \"$?\"\n"
+	// A terminal call may enable errexit (`set -e`). Shell options persist just
+	// like cwd and exported variables, but errexit must not leak into the next
+	// call and kill the shell before its completion sentinel can run.
+	//
+	// The user command runs inside a brace group with </dev/null redirected on
+	// its stdin. Children like `adb`, `docker` and other daemon-forking clients
+	// inherit that closed stdin instead of the persistent shell's pipe, so they
+	// cannot keep the parent's stdout writer open after the foreground command
+	// returns. Without this, `adb shell monkey ...` prints its output, the
+	// pipeline exits, but the persistent shell blocks on the sentinel forever
+	// because the adb daemon still holds an inherited fd — the command times
+	// out at the full terminal.timeout even though the work is done.
+	script := "set +e\n{\n" + command + "\n} </dev/null\nprintf '\\n" + marker + "%s\\n' \"$?\"\n"
 	if _, err := io.WriteString(s.stdin, script); err != nil {
 		s.dead = true
 		return "", -1, fmt.Errorf("write to shell: %w", err)

--- a/internal/tools/shell_test.go
+++ b/internal/tools/shell_test.go
@@ -3,7 +3,10 @@ package tools
 import (
 	"context"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,5 +61,51 @@ func TestDefaultShellCommandEmitsCompletionSentinel(t *testing.T) {
 	}
 	if code != 0 || out != "ANTARES_SHELL_OK" {
 		t.Fatalf("command result = (%q, %d), want (%q, 0)", out, code, "ANTARES_SHELL_OK")
+	}
+}
+
+// TestPersistentShellClosesInheritedStdinForDaemonForkingClients guards against
+// the adb regression: a client like `adb` forks a background daemon at first
+// invocation, and that daemon inherits every fd of the persistent shell it was
+// launched from. Without redirecting stdin to /dev/null, bash then blocks on
+// the completion sentinel forever because a reader on its stdin pipe is still
+// alive, so a command that finished in milliseconds times out at
+// terminal.timeout (300 s) instead.
+func TestPersistentShellClosesInheritedStdinForDaemonForkingClients(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX persistent shell protocol does not apply on Windows")
+	}
+	if _, err := exec.LookPath("setsid"); err != nil {
+		t.Skip("setsid unavailable — cannot simulate a daemon-forking client")
+	}
+
+	m := NewShellManager(config.Terminal{Shell: "/bin/bash"})
+	t.Cleanup(m.CloseAll)
+	sess, err := m.session("daemon-session", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pidFile := filepath.Join(t.TempDir(), "daemon.pid")
+	command := "setsid /bin/sh -c 'sleep 60' >/dev/null 2>&1 & echo $! >" + pidFile + "; echo parent-done"
+	start := time.Now()
+	out, code, err := sess.run(context.Background(), command, 3*time.Second, nil)
+	elapsed := time.Since(start)
+
+	// Clean up the lingering child before asserting so a slow assertion path
+	// does not leak a stray process into the test environment.
+	if raw, readErr := os.ReadFile(pidFile); readErr == nil {
+		if pid := strings.TrimSpace(string(raw)); pid != "" {
+			_ = exec.Command("/bin/sh", "-c", "kill -TERM "+pid+" 2>/dev/null || true").Run()
+		}
+	}
+	if err != nil {
+		t.Fatalf("daemon-forking command did not complete via sentinel: %v", err)
+	}
+	if code != 0 || !strings.Contains(out, "parent-done") {
+		t.Fatalf("command result = (%q, %d), want parent-done and code 0", out, code)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("sentinel arrived after %s — the shell blocked on the daemon's inherited stdin", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

Foreground `terminal` calls whose command transitively starts a daemon (adb, docker, gpg-agent, dbus, browser launchers, etc.) would block on the completion sentinel until the full `terminal.timeout` (default 300 s), even though the visible work finished in milliseconds.

The persistent shell now wraps every user command in a brace group whose stdin is redirected to `/dev/null`, so children cannot cling to the shell's stdin pipe after the foreground pipeline returns.

## Root cause

`adb`, on first invocation, forks a background daemon that inherits every fd of its launching shell. The daemon then keeps a reader on the shell's stdin pipe alive forever. bash cannot flush the next line — the completion sentinel — because it is still blocked servicing the pipe. Reproduced on this host:

- before: 300.002 s per adb call, then `context deadline exceeded`
- after: 2.7 s, same stdout

## Regression coverage

- new `TestPersistentShellClosesInheritedStdinForDaemonForkingClients` uses `setsid /bin/sh -c 'sleep 60' &` inside the persistent shell and asserts the sentinel arrives inside 2 s, then reaps the strayed child
- existing sentinel, errexit-does-not-leak, and shell-exit-recovers tests still pass

## Verification

- `go test -race ./internal/tools`
- `make check`
- Windows amd64 cross-build
- Brave smoke: 15/15 routes
- deployed binary reproduces the fix end-to-end against a live device (adb monkey completes in ~2.7 s)