### PR TITLE
Harden stale edit diagnostics and prompt lessons

### DIFF
--- a/internal/agent/learn.go
+++ b/internal/agent/learn.go
@@ -104,11 +104,21 @@ func (a *Agent) lessonsBlock(ctx context.Context) string {
 		return ""
 	}
 	var lessons []string
+	seen := make(map[string]struct{})
 	for _, m := range items {
 		if m.Source == lessonSource {
-			lessons = append(lessons, m.Content)
+			lesson := strings.TrimSpace(m.Content)
+			if !usableLesson(lesson) {
+				continue
+			}
+			key := strings.ToLower(lesson)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			lessons = append(lessons, lesson)
 		}
-		if len(lessons) >= 20 {
+		if len(lessons) >= 12 {
 			break
 		}
 	}
@@ -122,4 +132,21 @@ func (a *Agent) lessonsBlock(ctx context.Context) string {
 		b.WriteString("- " + l + "\n")
 	}
 	return b.String()
+}
+
+// usableLesson keeps malformed auxiliary-model output out of the system
+// prompt. Historical rows include fragments such as "NONE", "Wait", and
+// duplicated partial sentences; presenting them as instructions makes tool
+// behavior less predictable and wastes context.
+func usableLesson(s string) bool {
+	if len(s) < 32 || len(s) > 400 {
+		return false
+	}
+	if strings.EqualFold(s, "none") || strings.HasSuffix(strings.ToLower(s), " none") {
+		return false
+	}
+	if strings.EqualFold(s, "wait") || strings.EqualFold(s, ".") {
+		return false
+	}
+	return true
 }

--- a/internal/agent/learn_test.go
+++ b/internal/agent/learn_test.go
@@ -1,0 +1,20 @@
+package agent
+
+import "testing"
+
+func TestUsableLessonRejectsAuxiliaryFragments(t *testing.T) {
+	for _, lesson := range []string{"NONE", "Wait", ".", "When `edit_file"} {
+		if usableLesson(lesson) {
+			t.Errorf("malformed lesson accepted: %q", lesson)
+		}
+	}
+	if !usableLesson("When edit_file fails with old_string not found, read the current file and copy exact whitespace before retrying.") {
+		t.Fatal("valid lesson rejected")
+	}
+}
+
+func TestUsableLessonRejectsTrailingNone(t *testing.T) {
+	if usableLesson("When a tool fails, inspect the concrete error and retry with corrected arguments. NONE") {
+		t.Fatal("auxiliary NONE suffix should not enter the prompt")
+	}
+}

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -106,7 +106,7 @@ help them now — do not block them.
 			// paste line numbers into old_string or expand tabs to spaces and
 			// the exact match fails repeatedly.
 			b.WriteString("- read_file returns lines as `NUMBER|CONTENT`. The `|` is metadata only. When calling edit_file, copy **only** the content after `|` into old_string/new_string — never the line number. Preserve tabs and spaces exactly (do not expand tabs to spaces). Line endings are matched automatically.\n")
-			b.WriteString("- edit_file requires an exact, unique old_string from the current file. After any successful edit or write, re-read before making another edit; do not reuse an older block or invent identifiers. If it reports multiple occurrences, include unique neighbouring lines or use replace_all only when every occurrence should change.\n")
+			b.WriteString("- Before every edit_file call, read the current target file first. edit_file requires an exact, unique old_string from that fresh read. After any successful edit or write, re-read before making another edit; do not reuse an older block or invent identifiers. If it reports multiple occurrences, include unique neighbouring lines or use replace_all only when every occurrence should change.\n")
 		}
 		if hasTool(active, "vps_upload") || hasTool(active, "vps_download") || hasTool(active, "vps_run") {
 			// Without this, models fall back to terminal rsync/scp and never use

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -106,6 +106,7 @@ help them now — do not block them.
 			// paste line numbers into old_string or expand tabs to spaces and
 			// the exact match fails repeatedly.
 			b.WriteString("- read_file returns lines as `NUMBER|CONTENT`. The `|` is metadata only. When calling edit_file, copy **only** the content after `|` into old_string/new_string — never the line number. Preserve tabs and spaces exactly (do not expand tabs to spaces). Line endings are matched automatically.\n")
+			b.WriteString("- edit_file requires an exact, unique old_string from the current file. After any successful edit or write, re-read before making another edit; do not reuse an older block or invent identifiers. If it reports multiple occurrences, include unique neighbouring lines or use replace_all only when every occurrence should change.\n")
 		}
 		if hasTool(active, "vps_upload") || hasTool(active, "vps_download") || hasTool(active, "vps_run") {
 			// Without this, models fall back to terminal rsync/scp and never use

--- a/internal/tools/file.go
+++ b/internal/tools/file.go
@@ -417,6 +417,7 @@ func stripReadFileLinePrefixes(s string) (string, bool) {
 // the two failure modes that read_file → edit_file commonly hits:
 //  1. LF vs CRLF (read_file always displays LF)
 //  2. pasted NUMBER| line prefixes from read_file output
+//  3. a unique near-match when new_string only inserts adjacent text
 //
 // how is a short note for the success message when recovery was used; empty on
 // a plain exact match.
@@ -460,7 +461,104 @@ func resolveEditMatch(content, oldIn, newIn string) (oldString, newString string
 		}
 	}
 
+	// 3. A common README/table operation copies a line from an earlier read,
+	// abbreviates one phrase, and adds a new row immediately after it. Recover
+	// only that narrow insertion shape, and only when one file line is a clear
+	// unique match. The actual on-disk line is retained, so stale wording is not
+	// silently overwritten. Ordinary replacements remain exact-only.
+	if oldLine, newLine, ok := resolveAdjacentInsertion(content, oldIn, newIn, eol); ok {
+		return oldLine, newLine, 1, "matched unique near line for adjacent insertion"
+	}
+
 	return oldIn, newIn, 0, ""
+}
+
+func resolveAdjacentInsertion(content, oldIn, newIn, eol string) (oldLine, newLine string, ok bool) {
+	oldNorm := toEOL(oldIn, "\n")
+	newNorm := toEOL(newIn, "\n")
+	if oldNorm == "" || strings.Contains(oldNorm, "\n") {
+		return "", "", false
+	}
+
+	mode := 0 // 1 = insert after, 2 = insert before
+	insert := ""
+	if strings.HasPrefix(newNorm, oldNorm+"\n") {
+		mode = 1
+		insert = strings.TrimPrefix(newNorm, oldNorm)
+	} else if strings.HasSuffix(newNorm, "\n"+oldNorm) {
+		mode = 2
+		insert = strings.TrimSuffix(newNorm, oldNorm)
+	} else {
+		return "", "", false
+	}
+
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	lines := strings.Split(normalized, "\n")
+	best, second := -1.0, -1.0
+	bestLine := -1
+	for i, line := range lines {
+		if line == "" && i == len(lines)-1 {
+			continue
+		}
+		score := editLineSimilarity(oldNorm, line)
+		if score > best {
+			second, best = best, score
+			bestLine = i
+		} else if score > second {
+			second = score
+		}
+	}
+	if bestLine < 0 || best < 0.78 || (second >= 0 && best-second < 0.12) {
+		return "", "", false
+	}
+
+	actual := lines[bestLine]
+	if mode == 1 {
+		newLine = actual + insert
+	} else {
+		newLine = insert + actual
+	}
+	return toEOL(actual, eol), toEOL(newLine, eol), true
+}
+
+func editLineSimilarity(a, b string) float64 {
+	aSet := editTokenSet(a)
+	bSet := editTokenSet(b)
+	if len(aSet) == 0 || len(bSet) == 0 {
+		return 0
+	}
+	common := 0
+	for token := range aSet {
+		if _, ok := bSet[token]; ok {
+			common++
+		}
+	}
+	return float64(common) / float64(len(aSet)+len(bSet)-common)
+}
+
+func editTokenSet(s string) map[string]struct{} {
+	set := make(map[string]struct{})
+	start := -1
+	flush := func(end int) {
+		if start >= 0 && end-start >= 2 {
+			set[strings.ToLower(s[start:end])] = struct{}{}
+		}
+		start = -1
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		isToken := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+		if isToken {
+			if start < 0 {
+				start = i
+			}
+		} else {
+			flush(i)
+		}
+	}
+	flush(len(s))
+	return set
 }
 
 // editNotFoundMessage explains why an edit missed, with actionable recovery

--- a/internal/tools/file.go
+++ b/internal/tools/file.go
@@ -325,7 +325,7 @@ func (editFileTool) Execute(_ context.Context, in Input) Result {
 	case count == 0:
 		return Errorf("%s", editNotFoundMessage(args.Path, content, args.OldString))
 	case count > 1 && !args.ReplaceAll:
-		return Errorf("old_string appears %d times in %s; add more surrounding context or set replace_all", count, args.Path)
+		return Errorf("%s", editAmbiguousMessage(args.Path, content, oldString, count))
 	}
 
 	var updated string
@@ -488,8 +488,138 @@ func editNotFoundMessage(path, content, oldString string) string {
 		}
 	}
 
+	// A mixed paste usually means the model copied the display prefix from only
+	// one or two read_file lines. Do not silently strip it: the unprefixed lines
+	// may contain literal pipe characters.
+	if prefixed, total := readFileLinePrefixCounts(oldString); prefixed > 0 && prefixed < total {
+		b.WriteString(" Some old_string lines still include read_file line numbers (NUMBER|) while others do not. Remove every numeric prefix and keep only the text after each |, then retry from a fresh read.")
+		return b.String()
+	}
+	if hint := nearMissHint(content, oldString); hint != "" {
+		b.WriteByte(' ')
+		b.WriteString(hint)
+		return b.String()
+	}
+
 	b.WriteString(" Read the file first and copy only the content after the NUMBER| separator; preserve tabs, spaces, and indentation exactly.")
 	return b.String()
+}
+
+func readFileLinePrefixCounts(s string) (prefixed, total int) {
+	lines := strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+	if len(lines) > 1 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	for _, line := range lines {
+		total++
+		i := strings.IndexByte(line, '|')
+		if i > 0 {
+			allDigits := true
+			for _, c := range line[:i] {
+				if c < '0' || c > '9' {
+					allDigits = false
+					break
+				}
+			}
+			if allDigits {
+				prefixed++
+			}
+		}
+	}
+	return prefixed, total
+}
+
+func editAmbiguousMessage(path, content, oldString string, count int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "old_string appears %d times in %s; add unique surrounding context or set replace_all only if every occurrence should change.", count, path)
+	if lines := occurrenceLines(content, oldString, 12); len(lines) > 0 {
+		b.WriteString(" Current match line(s): ")
+		for i, line := range lines {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			fmt.Fprintf(&b, "%d", line)
+		}
+		b.WriteByte('.')
+	}
+	b.WriteString(" Re-read the current file and include enough neighbouring lines for exactly one match.")
+	return b.String()
+}
+
+func occurrenceLines(content, needle string, max int) []int {
+	if needle == "" || max <= 0 {
+		return nil
+	}
+	var lines []int
+	for from := 0; from < len(content) && len(lines) < max; {
+		i := strings.Index(content[from:], needle)
+		if i < 0 {
+			break
+		}
+		at := from + i
+		lines = append(lines, 1+strings.Count(content[:at], "\n"))
+		from = at + len(needle)
+	}
+	return lines
+}
+
+// nearMissHint reports a few real lines sharing a distinctive identifier with
+// old_string. It is intentionally short and bounded: the tool should correct
+// the model's stale context without dumping the file into an error response.
+func nearMissHint(content, oldString string) string {
+	for _, token := range identifierTokens(oldString) {
+		if len(token) < 8 || strings.Contains(strings.ToLower(token), "read_file") {
+			continue
+		}
+		var hits []string
+		for i, line := range strings.Split(content, "\n") {
+			if strings.Contains(line, token) {
+				line = strings.TrimRight(line, "\r")
+				if len(line) > 180 {
+					line = line[:180] + "..."
+				}
+				hits = append(hits, fmt.Sprintf("line %d: %s", i+1, line))
+				if len(hits) == 3 {
+					break
+				}
+			}
+		}
+		if len(hits) > 0 {
+			return "Near-miss lines sharing a token (re-read them; do not invent identifiers): " + strings.Join(hits, " ")
+		}
+	}
+	return ""
+}
+
+func identifierTokens(s string) []string {
+	var out []string
+	start := -1
+	flush := func(end int) {
+		if start >= 0 && end-start >= 8 {
+			out = append(out, s[start:end])
+		}
+		start = -1
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		isID := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+		if isID {
+			if start < 0 {
+				start = i
+			}
+		} else {
+			flush(i)
+		}
+	}
+	flush(len(s))
+	for i := 0; i < len(out); i++ {
+		for j := i + 1; j < len(out); j++ {
+			if len(out[j]) > len(out[i]) {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	return out
 }
 
 // expandTabs replaces leading and embedded tabs with spaces at the given width

--- a/internal/tools/file_edit_regression_test.go
+++ b/internal/tools/file_edit_regression_test.go
@@ -142,6 +142,33 @@ func TestEditFileDiagnosesTabVsSpaceMismatch(t *testing.T) {
 	}
 }
 
+func TestEditFileAmbiguousListsCurrentMatchLines(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "repeat.go")
+	content := "func a() {\n\treturn value\n}\nfunc b() {\n\treturn value\n}\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	args, _ := json.Marshal(map[string]any{"path": "repeat.go", "old_string": "\treturn value", "new_string": "\treturn other"})
+	result := (editFileTool{}).Execute(context.Background(), Input{Workspace: workspace, Args: args})
+	if !result.IsError || !strings.Contains(result.Content, "Current match line(s): 2, 5") {
+		t.Fatalf("unexpected ambiguity result: %+v", result)
+	}
+}
+
+func TestEditFileNotFoundShowsNearMiss(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "names.go")
+	if err := os.WriteFile(path, []byte("func attachEntity() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	args, _ := json.Marshal(map[string]any{"path": "names.go", "old_string": "func attachEntit() {}", "new_string": "func attachEntity2() {}"})
+	result := (editFileTool{}).Execute(context.Background(), Input{Workspace: workspace, Args: args})
+	if !result.IsError || !strings.Contains(result.Content, "attachEntity") {
+		t.Fatalf("near-miss missing from result: %+v", result)
+	}
+}
+
 func TestStripReadFileLinePrefixes(t *testing.T) {
 	in := "10|\tfoo()\n11|\tbar()\n12|}"
 	got, ok := stripReadFileLinePrefixes(in)
@@ -158,5 +185,20 @@ func TestStripReadFileLinePrefixes(t *testing.T) {
 	// Single line of real data that happens to contain a pipe stays intact.
 	if s, ok := stripReadFileLinePrefixes("nope"); ok || s != "nope" {
 		t.Fatalf("non-prefixed = %q ok=%v", s, ok)
+	}
+}
+
+func TestEditFileDiagnosesMixedReadPrefixes(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "mixed.go")
+	if err := os.WriteFile(path, []byte("func run() {\n\treturn\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	args, _ := json.Marshal(map[string]any{
+		"path": "mixed.go", "old_string": "1|func run() {\n\treturn\n}", "new_string": "1|func run() {\n\treturn nil\n}",
+	})
+	result := (editFileTool{}).Execute(context.Background(), Input{Workspace: workspace, Args: args})
+	if !result.IsError || !strings.Contains(result.Content, "Some old_string lines still include") {
+		t.Fatalf("mixed-prefix diagnostic missing: %+v", result)
 	}
 }

--- a/internal/tools/file_edit_regression_test.go
+++ b/internal/tools/file_edit_regression_test.go
@@ -169,6 +169,54 @@ func TestEditFileNotFoundShowsNearMiss(t *testing.T) {
 	}
 }
 
+func TestEditFileRecoversUniqueNearInsertionWithoutChangingExistingLine(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "README.md")
+	actual := "| **pool39v2** | 14 hand + 25 vision-audited | 33 train / 6 val | T4 | 85 (early stop @55) | **0.009** | `artifacts/pool39v2/` |\n"
+	if err := os.WriteFile(path, []byte(actual), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := "| **pool39v2** | 14 hand + 25 vision-audited | 33 train / 6 val | T4 | 85 (ES@55) | **0.009** | `artifacts/pool39v2/` |"
+	newString := old + "\n| **pool39v2_sc** | single-class icon | 33 train / 6 val | T4 | 70 | **0.519** | `artifacts/pool39v2_sc/` |"
+	args, _ := json.Marshal(map[string]any{"path": "README.md", "old_string": old, "new_string": newString})
+	result := (editFileTool{}).Execute(context.Background(), Input{Workspace: workspace, Args: args})
+	if result.IsError {
+		t.Fatalf("unique adjacent insertion should recover: %s", result.Content)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := actual + "| **pool39v2_sc** | single-class icon | 33 train / 6 val | T4 | 70 | **0.519** | `artifacts/pool39v2_sc/` |\n"
+	if string(got) != want {
+		t.Fatalf("recovery changed the existing line:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestEditFileDoesNotRecoverAmbiguousNearInsertion(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "README.md")
+	content := "| **pool39v2** | 85 (early stop @55) | artifacts/a |\n| **pool39v2** | 85 (early stop @55) | artifacts/b |\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := "| **pool39v2** | 85 (ES@55) | artifacts/c |"
+	args, _ := json.Marshal(map[string]any{
+		"path": "README.md", "old_string": old, "new_string": old + "\n| new row |",
+	})
+	result := (editFileTool{}).Execute(context.Background(), Input{Workspace: workspace, Args: args})
+	if !result.IsError || !strings.Contains(result.Content, "old_string not found") {
+		t.Fatalf("ambiguous near insertion must remain exact-only: %+v", result)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Fatalf("ambiguous recovery modified file: %q", got)
+	}
+}
+
 func TestStripReadFileLinePrefixes(t *testing.T) {
 	in := "10|\tfoo()\n11|\tbar()\n12|}"
 	got, ok := stripReadFileLinePrefixes(in)


### PR DESCRIPTION
## Summary

- diagnose ambiguous edit_file matches with current line numbers
- surface bounded near-miss context and mixed NUMBER| prefix errors for stale edits
- require fresh, exact, unique edit context in the system prompt
- filter malformed and duplicate learned lessons before prompt injection

## Evidence

Database review found 50 edit_file failures: 41 stale/not-found old_string values and 6 ambiguous matches. Read and grep failures were invalid paths, offsets, or regex inputs rather than silent file corruption.

## Tests

- GOCACHE=/tmp/antares-go-cache GOPROXY=off GOSUMDB=off go test ./internal/tools ./internal/agent
- GOCACHE=/tmp/antares-go-cache GOPROXY=off GOSUMDB=off go test -race ./internal/tools