### PR TITLE
fix(mcp): connect servers immediately after dashboard install

### DIFF
--- a/internal/server/handlers_hub.go
+++ b/internal/server/handlers_hub.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -159,10 +158,6 @@ func (s *Server) handleHubInstallMCP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
-	if s.mcp != nil {
-		// Connecting can take seconds while npx downloads a package; the
-		// request must not wait on it, and neither must its context.
-		go s.mcp.Connect(context.Background(), s.config())
-	}
+	s.refreshMCPConnections(r.Context())
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "missing_keys": missing})
 }

--- a/internal/server/handlers_mcp.go
+++ b/internal/server/handlers_mcp.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -89,11 +88,7 @@ func (s *Server) handleAddMCPServer(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
-	if s.mcp != nil {
-		// Connecting can take seconds while npx downloads a package; do it off
-		// the request so the form returns promptly.
-		go s.mcp.Connect(context.Background(), s.config())
-	}
+	s.refreshMCPConnections(r.Context())
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "name": name})
 }
 
@@ -121,9 +116,7 @@ func (s *Server) handleDeleteMCPServer(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
-	if s.mcp != nil {
-		go s.mcp.Connect(context.Background(), s.config())
-	}
+	s.refreshMCPConnections(r.Context())
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 

--- a/internal/server/handlers_subsystems.go
+++ b/internal/server/handlers_subsystems.go
@@ -366,18 +366,25 @@ func (s *Server) handleMCPStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleMCPRefresh(w http.ResponseWriter, r *http.Request) {
-	// Check the concrete pointer before boxing it: a nil *mcp.Manager inside a
-	// non-nil mcpRefresher interface would slip past the nil guard in refreshMCP
-	// and panic on the first field access in Refresh.
-	if s.mcp == nil {
-		s.refreshMCP(w, r, nil)
-		return
+	refresher := s.mcpRefresh
+	if refresher == nil {
+		refresher = s.mcp
 	}
-	s.refreshMCP(w, r, s.mcp)
+	s.refreshMCP(w, r, refresher)
 }
 
 type mcpRefresher interface {
 	Refresh(context.Context, *config.Config) []mcp.ServerStatus
+}
+
+func (s *Server) refreshMCPConnections(ctx context.Context) {
+	refresher := s.mcpRefresh
+	if refresher == nil {
+		refresher = s.mcp
+	}
+	if refresher != nil {
+		refresher.Refresh(ctx, s.config())
+	}
 }
 
 func (s *Server) refreshMCP(w http.ResponseWriter, r *http.Request, refresher mcpRefresher) {

--- a/internal/server/mcp_refresh_test.go
+++ b/internal/server/mcp_refresh_test.go
@@ -3,12 +3,13 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-
+	"github.com/enowdev/antares/internal/agent"
 	"github.com/enowdev/antares/internal/config"
 	"github.com/enowdev/antares/internal/mcp"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 )
 
 type fakeMCPRefresher struct {
@@ -23,6 +24,92 @@ func (f *fakeMCPRefresher) Refresh(context.Context, *config.Config) []mcp.Server
 		Connected: true,
 		Tools:     []mcp.ToolDef{{Name: "server_health"}},
 	}}
+}
+
+type fakeMCPManager struct {
+	refreshed bool
+	cfg       *config.Config
+}
+
+func (f *fakeMCPManager) Refresh(_ context.Context, cfg *config.Config) []mcp.ServerStatus {
+	f.refreshed = true
+	f.cfg = cfg
+	return nil
+}
+
+func (f *fakeMCPManager) Status(*config.Config) []mcp.ServerStatus { return nil }
+
+func newMCPMutationServer(t *testing.T) (*Server, *fakeMCPManager) {
+	t.Helper()
+	t.Setenv("ANTARES_HOME", t.TempDir())
+	cfg := config.Default()
+	cfg.Server.DashboardPasswordHash = "test-hash"
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	manager := &fakeMCPManager{}
+	return &Server{cfg: cfg, agent: &agent.Agent{}, mcpRefresh: manager, reloadFn: func() error { return nil }}, manager
+}
+
+func TestAddMCPServerRefreshesManager(t *testing.T) {
+	s, manager := newMCPMutationServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp/servers", strings.NewReader(`{"name":"manual","transport":"http","url":"http://127.0.0.1:8080/mcp"}`))
+	w := httptest.NewRecorder()
+
+	s.handleAddMCPServer(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !manager.refreshed {
+		t.Fatal("adding a server did not refresh MCP connections")
+	}
+	if _, ok := manager.cfg.MCP.Servers["manual"]; !ok {
+		t.Fatalf("refresh config = %+v, want manually added server", manager.cfg.MCP.Servers)
+	}
+}
+
+func TestHubInstallMCPRefreshesManager(t *testing.T) {
+	s, manager := newMCPMutationServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/hub/mcp/install", strings.NewReader(`{"id":"filesystem"}`))
+	w := httptest.NewRecorder()
+
+	s.handleHubInstallMCP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !manager.refreshed {
+		t.Fatal("installing a hub server did not refresh MCP connections")
+	}
+	if _, ok := manager.cfg.MCP.Servers["filesystem"]; !ok {
+		t.Fatalf("refresh config = %+v, want installed hub server", manager.cfg.MCP.Servers)
+	}
+}
+
+func TestDeleteMCPServerRefreshesManager(t *testing.T) {
+	s, manager := newMCPMutationServer(t)
+	cfg := s.cfg
+	cfg.MCP.Enabled = true
+	cfg.MCP.Servers = map[string]config.MCPServer{
+		"remove-me": {Transport: "http", URL: "http://127.0.0.1:8080/mcp", Enabled: true},
+	}
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("seed configured server: %v", err)
+	}
+	s.cfg = cfg
+	req := httptest.NewRequest(http.MethodDelete, "/api/mcp/servers/remove-me", nil)
+	req.SetPathValue("name", "remove-me")
+	w := httptest.NewRecorder()
+
+	s.handleDeleteMCPServer(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !manager.refreshed {
+		t.Fatal("deleting a server did not refresh MCP connections")
+	}
+	if _, ok := manager.cfg.MCP.Servers["remove-me"]; ok {
+		t.Fatal("refresh config still contains deleted server")
+	}
 }
 
 func TestMCPRefreshHandlerReturnsFreshStatus(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,18 +32,19 @@ import (
 
 // Server wires the API handlers to the agent and store.
 type Server struct {
-	cfg     *config.Config
-	agent   *agent.Agent
-	db      store.Store
-	skills  *skills.Manager
-	cron    *cron.Runner
-	gateway *gateway.Manager
-	mcp     *mcp.Manager
-	social  *socialbrowser.Manager
-	mux     *http.ServeMux
-	hub     *liveHub
-	wake    *wakeQueue
-	started time.Time
+	cfg        *config.Config
+	agent      *agent.Agent
+	db         store.Store
+	skills     *skills.Manager
+	cron       *cron.Runner
+	gateway    *gateway.Manager
+	mcp        *mcp.Manager
+	mcpRefresh mcpRefresher
+	social     *socialbrowser.Manager
+	mux        *http.ServeMux
+	hub        *liveHub
+	wake       *wakeQueue
+	started    time.Time
 
 	// distFS holds the embedded dashboard build, when present.
 	distFS fs.FS


### PR DESCRIPTION
## Summary

Fixes newly added MCP servers remaining unavailable until the user manually clicks **Refresh**.

Both dashboard installation paths now run the shared MCP refresh lifecycle after saving and reloading configuration:

- Manual **Add server**
- MCP **Browse** installation

Deleting a server also refreshes the manager immediately, removing its registered tools and closing obsolete transports.

## Implementation

Replaces the background `Manager.Connect` calls with the serialized `Manager.Refresh` lifecycle. This ensures that, before the mutation response returns:

- Configured servers are connected
- Connection errors are reflected in dashboard status
- MCP tools are published to the agent registry
- Removed tools are unregistered
- Replaced transports are closed

## Verification

- `go test ./...`
- `go test -race ./internal/server ./internal/mcp`
- `bun run typecheck`
- `bun test`
- Focused tests for manual add, Browse install, deletion, and tool registry replacement