### PR TITLE
fix(perf): preallocate bounded slice results

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1240,7 +1240,7 @@ func ensureToolResults(msgs []llm.Message) []llm.Message {
 	// outside it. Reversing that order lets a turn whose result was compacted
 	// away reach forward and take the result of a later turn sharing its id,
 	// leaving the live call with a stub and the model with stale output.
-	byID := make(map[string][]int)
+	byID := make(map[string][]int, len(msgs))
 	for i, m := range msgs {
 		if m.Role == llm.RoleTool {
 			byID[m.ToolCallID] = append(byID[m.ToolCallID], i)
@@ -1255,7 +1255,7 @@ func ensureToolResults(msgs []llm.Message) []llm.Message {
 		end   int
 		bound []int // parallel to the turn's ToolCalls; -1 until a result binds
 	}
-	var turns []turn
+	turns := make([]turn, 0, len(msgs))
 	for i, m := range msgs {
 		if m.Role != llm.RoleAssistant {
 			continue

--- a/internal/agent/harness.go
+++ b/internal/agent/harness.go
@@ -708,7 +708,7 @@ func (a *Agent) Panel(ctx context.Context, question string, models []string, emi
 	}
 	wg.Wait()
 
-	var usable []PanelAnswer
+	usable := make([]PanelAnswer, 0, len(answers))
 	for _, ans := range answers {
 		if ans.Err == "" && strings.TrimSpace(ans.Answer) != "" {
 			usable = append(usable, ans)

--- a/internal/server/handlers_engagement.go
+++ b/internal/server/handlers_engagement.go
@@ -79,7 +79,7 @@ func (s *Server) handleEngagementSessions(w http.ResponseWriter, r *http.Request
 		Findings int    `json:"findings"`
 		Intel    int    `json:"intel"`
 	}
-	out := make([]row, 0)
+	out := make([]row, 0, len(sessions))
 	for _, sess := range sessions {
 		f, intel := 0, 0
 		if s.agent.Findings() != nil {

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -62,7 +62,7 @@ func (s *sqlStore) ListMemories(ctx context.Context, scope, scopeKey string, lim
 		return nil, err
 	}
 	defer rows.Close()
-	out := []Memory{}
+	out := make([]Memory, 0, limit)
 	for rows.Next() {
 		m, err := scanMemory(rows)
 		if err != nil {
@@ -103,7 +103,7 @@ func (s *sqlStore) SearchMemories(ctx context.Context, query string, limit int) 
 		}
 	}
 	defer rows.Close()
-	out := []Memory{}
+	out := make([]Memory, 0, limit)
 	for rows.Next() {
 		m, err := scanMemory(rows)
 		if err != nil {

--- a/internal/store/ops.go
+++ b/internal/store/ops.go
@@ -105,7 +105,7 @@ func (s *sqlStore) ListCronRuns(ctx context.Context, jobID string, limit int) ([
 		return nil, err
 	}
 	defer rows.Close()
-	out := []CronRun{}
+	out := make([]CronRun, 0, limit)
 	for rows.Next() {
 		var (
 			r        CronRun

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -136,7 +136,7 @@ func (s *sqlStore) ListSessions(ctx context.Context, f SessionFilter) ([]Session
 	}
 	defer rows.Close()
 
-	out := []Session{}
+	out := make([]Session, 0, limit)
 	for rows.Next() {
 		sess, err := scanSession(rows)
 		if err != nil {
@@ -326,7 +326,7 @@ func (s *sqlStore) SearchMessages(ctx context.Context, query string, limit int) 
 	}
 	defer rows.Close()
 
-	out := []SearchHit{}
+	out := make([]SearchHit, 0, limit)
 	for rows.Next() {
 		var (
 			h       SearchHit


### PR DESCRIPTION
## Summary

Preallocate slices where the output size is already bounded, reducing growth
reallocations in frequently used result-building paths.

Changes include:

- Preallocate bounded SQL result slices from their normalized query limits:
  - memory results
  - session results
  - message search results
  - cron runs
- Reserve bounded capacity for panel answers and transcript normalization.
- Preallocate engagement-session response rows from the bounded session list.
- Preserve existing result ordering, JSON shape, empty-slice behavior, and
  tool-result binding semantics.

## Validation

- `GOTOOLCHAIN=go1.26.3 go test ./...`
- `go vet ./...`
- `make check`
- Focused tests for `internal/store`, `internal/agent`, and `internal/server`
- Frontend tests: 12 passed, 0 failed