### PR TITLE
fix(lint): resolve go-critic findings

### DIFF
--- a/cmd/antares/setup.go
+++ b/cmd/antares/setup.go
@@ -483,7 +483,8 @@ func pickModel(ctx context.Context, cfg *config.Config, chosen providerChoice) s
 			rest = append(rest, id)
 		}
 		sort.Strings(rest)
-		suggestions = append(ordered, rest...)
+		ordered = append(ordered, rest...)
+		suggestions = ordered
 	}
 
 	if len(suggestions) == 0 {

--- a/internal/browser/cdp.go
+++ b/internal/browser/cdp.go
@@ -101,7 +101,8 @@ func (c *conn) readLoop() {
 			}
 			c.eventsMu.Lock()
 			// Keep the tail only; a chatty page would otherwise grow forever.
-			list := append(c.events[m.Method], m.Params)
+			list := c.events[m.Method]
+			list = append(list, m.Params)
 			if len(list) > 200 {
 				list = list[len(list)-200:]
 			}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -189,15 +189,16 @@ func walk(v reflect.Value, prefix, group string, out *[]Field) {
 		path := name
 		grp := group
 		fv := v.Field(i)
-		if prefix != "" {
+		switch {
+		case prefix != "":
 			path = prefix + "." + name
 			if hidden[path] {
 				continue
 			}
-		} else if fv.Kind() == reflect.Struct {
+		case fv.Kind() == reflect.Struct:
 			// A struct at the root names its own group; a bare scalar does not.
 			grp = name
-		} else {
+		default:
 			grp = "general"
 		}
 

--- a/internal/httpshim/curl.go
+++ b/internal/httpshim/curl.go
@@ -170,11 +170,12 @@ func runCurl(args []string) int {
 		return fallback("curl", args)
 	}
 	if method == "" {
-		if headOnly {
+		switch {
+		case headOnly:
 			method = "HEAD"
-		} else if haveBody {
+		case haveBody:
 			method = "POST"
-		} else {
+		default:
 			method = "GET"
 		}
 	}

--- a/internal/tools/imagegen.go
+++ b/internal/tools/imagegen.go
@@ -121,17 +121,18 @@ func (imageGenerateTool) Execute(ctx context.Context, in Input) Result {
 	}
 
 	var img []byte
-	if out.Data[0].B64 != "" {
+	switch {
+	case out.Data[0].B64 != "":
 		img, err = base64.StdEncoding.DecodeString(out.Data[0].B64)
 		if err != nil {
 			return Errorf("could not decode the image: %v", err)
 		}
-	} else if out.Data[0].URL != "" {
+	case out.Data[0].URL != "":
 		img, err = fetchBytes(ctx, out.Data[0].URL)
 		if err != nil {
 			return Errorf("could not download the image: %v", err)
 		}
-	} else {
+	default:
 		return Errorf("the image endpoint returned neither data nor a url")
 	}
 

--- a/internal/tools/osint_api.go
+++ b/internal/tools/osint_api.go
@@ -34,7 +34,7 @@ func usernameCandidates(local string) []string {
 	}
 	add(local)
 	add(strings.NewReplacer(".", "", "-", "", "_", "").Replace(local)) // collapse separators
-	add(regexp.MustCompile(`\d+$`).ReplaceAllString(local, ""))         // strip trailing digits
+	add(regexp.MustCompile(`\d+$`).ReplaceAllString(local, ""))        // strip trailing digits
 	return out
 }
 
@@ -205,7 +205,8 @@ func (osintEmailTool) Execute(ctx context.Context, in Input) Result {
 		return Errorf("%v", err)
 	}
 	email := strings.TrimSpace(strings.ToLower(args.Email))
-	if !strings.Contains(email, "@") {
+	local, domain, ok := strings.Cut(email, "@")
+	if !ok {
 		return Errorf("%q is not a valid email", email)
 	}
 	var b strings.Builder
@@ -249,8 +250,6 @@ func (osintEmailTool) Execute(ctx context.Context, in Input) Result {
 	// few normalised variants and hand them to the agent to cross-search with
 	// osint_username / osint_pivot — this is what turns an email into linked
 	// accounts instead of a dead end.
-	local := email[:strings.Index(email, "@")]
-	domain := email[strings.Index(email, "@")+1:]
 	cands := usernameCandidates(local)
 	fmt.Fprintf(&b, "\nUsername candidates (from the local part) — cross-search these:\n")
 	for _, c := range cands {

--- a/internal/tui/modal.go
+++ b/internal/tui/modal.go
@@ -357,12 +357,12 @@ func modalBox(t Theme) lipgloss.Style {
 
 // placeModal composites box at (x,y) over a dimmed copy of base, falling back to
 // a plain centred placement when the box is larger than the screen.
-func placeModal(base, box string, x, y, W, H int, t Theme) string {
-	if lipgloss.Width(box) > W || lipgloss.Height(box) > H {
-		return clampHeight(lipgloss.Place(W, H, lipgloss.Center, lipgloss.Center, box), H)
+func placeModal(base, box string, x, y, w, h int, t Theme) string {
+	if lipgloss.Width(box) > w || lipgloss.Height(box) > h {
+		return clampHeight(lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, box), h)
 	}
 	dim := lipgloss.NewStyle().Foreground(t.Faint)
-	return clampHeight(overlayBox(base, box, x, y, W, H, dim), H)
+	return clampHeight(overlayBox(base, box, x, y, w, h, dim), h)
 }
 
 // swatch renders a theme's palette as coloured dots for a visual preview.
@@ -374,28 +374,28 @@ func swatch(th Theme) string {
 }
 
 // overlayBox draws box at (x,y) over a dimmed, plain-text copy of base.
-func overlayBox(base, box string, x, y, W, H int, dim lipgloss.Style) string {
+func overlayBox(base, box string, x, y, w, h int, dim lipgloss.Style) string {
 	if x < 0 {
 		x = 0
 	}
 	if y < 0 {
 		y = 0
 	}
-	bp := dimPlain(base, W, H)
+	bp := dimPlain(base, w, h)
 	bl := strings.Split(box, "\n")
-	out := make([]string, H)
-	for i := 0; i < H; i++ {
+	out := make([]string, h)
+	for i := 0; i < h; i++ {
 		r := []rune(bp[i])
 		bi := i - y
 		if bi >= 0 && bi < len(bl) {
 			bw := lipgloss.Width(bl[bi])
 			lx := x
-			if lx > W {
-				lx = W
+			if lx > w {
+				lx = w
 			}
 			rx := x + bw
-			if rx > W {
-				rx = W
+			if rx > w {
+				rx = w
 			}
 			out[i] = dim.Render(string(r[:lx])) + bl[bi] + dim.Render(string(r[rx:]))
 		} else {
@@ -407,19 +407,19 @@ func overlayBox(base, box string, x, y, W, H int, dim lipgloss.Style) string {
 
 // dimPlain strips colour from base and normalises it to exactly H lines of W
 // runes, so a modal can be spliced in without worrying about ANSI state.
-func dimPlain(base string, W, H int) []string {
+func dimPlain(base string, w, h int) []string {
 	src := strings.Split(base, "\n")
-	out := make([]string, H)
-	for i := 0; i < H; i++ {
+	out := make([]string, h)
+	for i := 0; i < h; i++ {
 		line := ""
 		if i < len(src) {
 			line = stripANSI(src[i])
 		}
 		r := []rune(line)
-		if len(r) > W {
-			r = r[:W]
+		if len(r) > w {
+			r = r[:w]
 		}
-		for len(r) < W {
+		for len(r) < w {
 			r = append(r, ' ')
 		}
 		out[i] = string(r)


### PR DESCRIPTION
## Summary

Resolve all 12 findings reported by `go-critic check ./...` without changing the intended behavior.

## Changes

- Make append targets explicit in setup model ordering and CDP event buffering.
- Replace flagged if-else chains with condition switches.
- Split OSINT email addresses safely using `strings.Cut`.
- Normalize modal width and height parameter names.

## Validation

- `go test ./...`
- `go vet ./...`
- `go-critic check ./...`